### PR TITLE
Fix clear all operation button

### DIFF
--- a/extension/panel/panel.tsx
+++ b/extension/panel/panel.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import { FluentProvider, webLightTheme } from "@fluentui/react-components";
 import { PanelContainer } from "./panel-container";
 
 const apolloUIComponent = (
-  <FluentProvider theme={teamsLightTheme} style={{ width: "100%" }}>
+  <FluentProvider theme={webLightTheme} style={{ width: "100%" }}>
     <PanelContainer />
   </FluentProvider>
 );

--- a/extension/utils/generate-request-id.ts
+++ b/extension/utils/generate-request-id.ts
@@ -1,11 +1,12 @@
 export const generateRequestInfo = (
-  name: string
+  name: string,
+  action: string
 ): {
   requestId: string;
   sender: string;
 } => {
   return {
-    requestId: `${name}:${Date.now()}`,
+    requestId: `${name}:${action}:${Date.now()}`,
     sender: `${name}`,
   };
 };

--- a/extension/utils/send-message.ts
+++ b/extension/utils/send-message.ts
@@ -37,7 +37,7 @@ export const sendMessageViaEventTarget = (
       tabId,
     },
     requestInfo: {
-      ...generateRequestInfo(callerName),
+      ...generateRequestInfo(callerName, action),
     },
     data,
   };

--- a/extension/web-page/web-page-actions.ts
+++ b/extension/web-page/web-page-actions.ts
@@ -135,7 +135,7 @@ const sendMessageToContentScript = (
       tabId: 0,
     },
     requestInfo: {
-      ...generateRequestInfo(WEB_PAGE),
+      ...generateRequestInfo(WEB_PAGE, action),
     },
   };
   logMessage(`sending message from webpage`, { message });


### PR DESCRIPTION
Fix clear all operation button, where clearing all operation was leading to stop operations only.

`Cause` The requestId generated for Stop recording and Start recording was same. Due to which it was getting filtered as duplicate request.