### PR TITLE
Start operations recording when devtools are opened

### DIFF
--- a/extension/src/panel/hooks/use-panel-initialization.ts
+++ b/extension/src/panel/hooks/use-panel-initialization.ts
@@ -12,7 +12,7 @@ interface IUseSetBackgroundConnection {
   setBackgroundConnection: React.Dispatch<
     React.SetStateAction<browser.Runtime.Port | null>
   >;
-  panelRef: React.MutableRefObject<CustomEventTarget>;
+  panelEventTargetRef: React.MutableRefObject<CustomEventTarget>;
   tabIdRef: React.MutableRefObject<number>;
   setInitPanelComplete: React.Dispatch<React.SetStateAction<boolean>>;
   setClientIds: React.Dispatch<React.SetStateAction<string[] | null>>;
@@ -23,7 +23,7 @@ interface IUseSetBackgroundConnection {
   cleanUpsRef: React.MutableRefObject<(() => void)[]>;
 }
 export const usePanelInitialization = ({
-  panelRef,
+  panelEventTargetRef,
   setBackgroundConnection,
   setClientIds,
   setInitPanelComplete,
@@ -42,7 +42,7 @@ export const usePanelInitialization = ({
 
   useConnectToBackgroundServiceWorker(
     tabIdRef,
-    panelRef,
+    panelEventTargetRef,
     setBackgroundConnection,
     setClientIds,
     setInitPanelComplete,

--- a/extension/src/utils/constants.ts
+++ b/extension/src/utils/constants.ts
@@ -45,3 +45,5 @@ export const enum PANEL_PAGE_ACTIONS {
 export const enum BACKGROUND_ACTIONS {
   PORT_NOT_FOUND = "PORT_NOT_FOUND",
 }
+
+export const Default_Apollo_Client_Name = "Default Apollo Client";

--- a/extension/src/web-page/web-page-actions.ts
+++ b/extension/src/web-page/web-page-actions.ts
@@ -11,12 +11,13 @@ import {
   getLastSender,
   getPrivateAccess,
   IWatchQueryInfo,
+  Default_Apollo_Client_Name,
 } from "../utils";
-import type { Cache } from "@apollo/client/cache";
+import type { Cache, NormalizedCacheObject } from "@apollo/client/cache";
 import { IWebpageContext } from "./web-page.interface";
 import { ApolloInspector, IDataView } from "apollo-inspector";
 import { getApolloClientsObj } from "./web-page-utils";
-import { ApolloClient, InMemoryCache, ObservableQuery } from "@apollo/client";
+import { ApolloClient, ObservableQuery } from "@apollo/client";
 import { DocumentNode, VariableDefinitionNode } from "graphql";
 
 export const devtoolScriptLoadedAction = (context: IWebpageContext) => {
@@ -58,7 +59,7 @@ export const getCopyWholeCacheCB = (context: IWebpageContext) => {
   return (message: IMessagePayload) => {
     const { clientId } = message.data;
     const ac = getApolloClientByClientId(clientId);
-    const data = ac?.cache.data.data;
+    const data = (ac?.cache as any)?.data.data;
     sendMessageViaEventTarget(webpage, {
       action: WEBPAGE_ACTIONS.WHOLE_APOLLO_CACHE_DATA,
       callerName: Context.WEB_PAGE,
@@ -100,7 +101,7 @@ const getApolloClients = (): string[] => {
   }
 
   if (window.__APOLLO_CLIENT__) {
-    const values = ["default"];
+    const values = [Default_Apollo_Client_Name];
     if (isTestEnabled) {
       return generateRandomClients(values);
     }
@@ -112,29 +113,12 @@ const getApolloClients = (): string[] => {
 
 const getApolloClientByClientId = (
   clientId: string
-): ApolloClient<InMemoryCache> | undefined => {
-  const values = getApolloClientObjects();
+): ApolloClient<NormalizedCacheObject> | undefined => {
+  const values = getApolloClientsObj();
 
   const ac = values.find((value) => value.clientId === clientId);
 
-  return ac?.client;
-};
-
-const getApolloClientObjects = (): {
-  clientId: string;
-  client: any;
-}[] => {
-  if (window.__APOLLO_CLIENTS__ && window.__APOLLO_CLIENTS__.length) {
-    return window.__APOLLO_CLIENTS__;
-  }
-
-  if (window.__APOLLO_CLIENT__) {
-    const values = [{ clientId: "default", client: window.__APOLLO_CLIENT__ }];
-
-    return values;
-  }
-
-  return [];
+  return ac?.client as any;
 };
 
 const sendMessageToContentScript = (

--- a/extension/src/web-page/web-page-utils.ts
+++ b/extension/src/web-page/web-page-utils.ts
@@ -1,12 +1,21 @@
 import { IApolloClientObject } from "apollo-inspector";
+import { Default_Apollo_Client_Name } from "../utils";
 
 export const getApolloClientsObj = (): IApolloClientObject[] => {
-  if (window.__APOLLO_CLIENTS__) {
-    const result = window.__APOLLO_CLIENTS__.map((ac) => {
-      return { client: ac.client, clientId: ac.clientId };
-    });
-    return result;
+  if (window.__APOLLO_CLIENTS__ && window.__APOLLO_CLIENTS__.length) {
+    return window.__APOLLO_CLIENTS__;
   }
 
-  return [{ client: window.__APOLLO_CLIENT__, clientId: "default" }];
+  if (window.__APOLLO_CLIENT__) {
+    const values: IApolloClientObject[] = [
+      {
+        clientId: Default_Apollo_Client_Name,
+        client: window.__APOLLO_CLIENT__ as any,
+      },
+    ];
+
+    return values;
+  }
+
+  return [];
 };

--- a/src/operations-tracker-container.interface.ts
+++ b/src/operations-tracker-container.interface.ts
@@ -27,6 +27,7 @@ export type stylesClasses =
 
 export interface IOperationsTrackerContainer {
   apolloClientIds: string[];
+  shouldStartRecordingOnMount?: boolean;
   onCopy: (copyType: CopyType, data: ICopyData) => void;
   onRecordStart: (selectedApolloClientIds: string[]) => Observable<IDataView>;
   onRecordStop: () => void;

--- a/src/operations-tracker-container.tsx
+++ b/src/operations-tracker-container.tsx
@@ -42,7 +42,8 @@ export const OperationsTrackerContainerInner = (
   props: IOperationsTrackerContainer
 ) => {
   const classes = useStyles();
-  const { onCopy, onRecordStart, onRecordStop } = props;
+  const { onCopy, onRecordStart, onRecordStop, shouldStartRecordingOnMount } =
+    props;
   const {
     openDescription,
     operationsState,
@@ -74,6 +75,7 @@ export const OperationsTrackerContainerInner = (
             onRecordStart={onRecordStart}
             onRecordStop={onRecordStop}
             onCopy={onCopy}
+            shouldStartRecordingOnMount={shouldStartRecordingOnMount}
           />
           {mainSlot}
         </div>

--- a/src/store/vanilla-store.ts
+++ b/src/store/vanilla-store.ts
@@ -19,19 +19,19 @@ import { getColumnOptions } from "./states/get-column-options";
 export const createTrackerStore = () => {
   return createStore<IStore>((set: ISet) => {
     return {
-      ...getApolloOperationsDataStore(set),
-      ...getLoaderStore(set),
-      ...getIsRecordingStore(set),
       ...getApolloClients(set),
-      ...getTheme(set),
-      ...getSelectedApolloClientId(set),
       ...getApolloInspectorStopTracking(set),
-      ...getSearchBannerStore(set),
-      ...getErrorStore(set),
-      ...getSelectedTabStore(set),
-      ...getOpenDescriptionStore(set),
-      ...getFilterSetStore(set),
+      ...getApolloOperationsDataStore(set),
       ...getColumnOptions(set),
+      ...getErrorStore(set),
+      ...getFilterSetStore(set),
+      ...getIsRecordingStore(set),
+      ...getLoaderStore(set),
+      ...getOpenDescriptionStore(set),
+      ...getSearchBannerStore(set),
+      ...getSelectedApolloClientId(set),
+      ...getSelectedTabStore(set),
+      ...getTheme(set),
     };
   });
 };


### PR DESCRIPTION
Start operations recording when devtools are opened only for default client.

Below changes are made with this PR
1. Start recording when devtools are opened.
2. If recording is true, then upon reload continue recording the operations.
3. If recording is false, then upon reload it should stay as false.